### PR TITLE
FIX - failing if admin name is not 'Administrator'

### DIFF
--- a/threatmodel-Windows.json
+++ b/threatmodel-Windows.json
@@ -905,7 +905,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "user",
-        "target": "if((net user Administrator | findstr /C:'Account active') -match 'Yes') { 'Administrator account is active' } else { '' }",
+        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like \"*-500\"} | Select-Object -ExpandProperty Name); if(((net user $adminName) | findstr /C:\"Account active\") -match \"Yes\") { Write-Output \"$adminName account is active\" } else { Write-Output \"\" }",
         "education": []
       },
       "remediation": {
@@ -914,7 +914,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "system",
-        "target": "net user Administrator /active:no",
+        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like \"*-500\"} | Select-Object -ExpandProperty Name); net user $adminName /active:no",
         "education": [
           {
             "locale": "EN",
@@ -934,7 +934,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "system",
-        "target": "net user Administrator /active:yes",
+        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like \"*-500\"} | Select-Object -ExpandProperty Name); net user $adminName /active:yes",
         "education": [
           {
             "locale": "EN",

--- a/threatmodel-Windows.json
+++ b/threatmodel-Windows.json
@@ -905,7 +905,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "user",
-        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like \"*-500\"} | Select-Object -ExpandProperty Name); if(((net user $adminName) | findstr /C:\"Account active\") -match \"Yes\") { Write-Output \"$adminName account is active\" } else { Write-Output \"\" }",
+        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like '*-500'} | Select-Object -ExpandProperty Name); if(((net user $adminName) | findstr /C:'Account active') -match 'Yes') { Write-Output 'Built-in Administrator account enabled' } else { Write-Output '' }",
         "education": []
       },
       "remediation": {
@@ -914,7 +914,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "system",
-        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like \"*-500\"} | Select-Object -ExpandProperty Name); net user $adminName /active:no",
+        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like '*-500'} | Select-Object -ExpandProperty Name); net user $adminName /active:no",
         "education": [
           {
             "locale": "EN",
@@ -934,7 +934,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "system",
-        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like \"*-500\"} | Select-Object -ExpandProperty Name); net user $adminName /active:yes",
+        "target": "$adminName = (Get-WmiObject Win32_UserAccount | Where-Object {$_.SID -like '*-500'} | Select-Object -ExpandProperty Name); net user $adminName /active:yes",
         "education": [
           {
             "locale": "EN",


### PR DESCRIPTION
# Pull request

## Describe your changes
The check, remediation and rollback were failing if the Admin user was renamed to something else than "Administrator".
Now the admin name is found and given as a parameter to the command.
## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have added tests to prove that my code is effective
- [ ] I have made the corresponding changes to the documentation

## Additional notes

