### PR TITLE
Fix - RemoteSigned isn't default for local machine

### DIFF
--- a/threatmodel-Windows.json
+++ b/threatmodel-Windows.json
@@ -1246,7 +1246,7 @@
       }
     },
     {
-      "name": "ps not RemoteSigned",
+      "name": "PS execution policy unrestricted",
       "metrictype": "bool",
       "dimension": "system integrity",
       "severity": 4,
@@ -1260,13 +1260,13 @@
       "description": [
         {
           "locale": "EN",
-          "title": "PowerShell execution policy not set to RemoteSigned",
-          "summary": "PowerShell is a powerful command-line tool that is built into Windows, and is often used by attackers to carry out malicious activities. The execution policy determines which scripts are allowed to run on a Windows system. If the execution policy is not set to RemoteSigned, it could allow an attacker to run malicious scripts on your system."
+          "title": "PowerShell execution policy not securely configured",
+          "summary": "PowerShell is a powerful command-line tool that is built into Windows, and is often used by attackers to carry out malicious activities. The execution policy determines which scripts are allowed to run on a Windows system. If the execution policy is set to Unrestricted, it could allow an attacker to run malicious scripts on your system."
         },
         {
           "locale": "FR",
-          "title": "La stratégie d'exécution de PowerShell n'est pas définie sur RemoteSigned",
-          "summary": "PowerShell est un outil en ligne de commande puissant intégré à Windows, souvent utilisé par des attaquants pour effectuer des activités malveillantes. La stratégie d'exécution détermine les scripts autorisés à s'exécuter sur un système Windows. Si la stratégie d'exécution n'est pas définie sur RemoteSigned, cela pourrait permettre à un attaquant d'exécuter des scripts malveillants sur votre système."
+          "title": "La stratégie d'exécution de PowerShell n'est pas sécurisée",
+          "summary": "PowerShell est un outil en ligne de commande puissant intégré à Windows, souvent utilisé par des attaquants pour effectuer des activités malveillantes. La stratégie d'exécution détermine les scripts autorisés à s'exécuter sur un système Windows. Si la stratégie d'exécution est pas définie sur Unrestricted, cela pourrait permettre à un attaquant d'exécuter des scripts malveillants sur votre système."
         }
       ],
       "implementation": {
@@ -1275,7 +1275,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "user",
-        "target": "if((Get-ExecutionPolicy) -ne 'RemoteSigned') { 'Execution Policy not RemoteSigned' } else { '' }",
+        "target": "$currentUserPolicy= Get-ExecutionPolicy -Scope CurrentUser; if($currentUserPolicy -eq 'Unrestricted') { 'Execution Policy is unrestricted' } else { '' }",
         "education": []
       },
       "remediation": {
@@ -1284,17 +1284,17 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "system",
-        "target": "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force",
+        "target": "Set-ExecutionPolicy -ExecutionPolicy Default -Scope CurrentUser",
         "education": [
           {
             "locale": "EN",
             "class": "html",
-            "target": "<p>Setting PowerShell's execution policy to RemoteSigned helps prevent the execution of malicious scripts by requiring that all scripts and configuration files downloaded from the Internet are signed by a trusted publisher. This setting is a balance between security and functionality, allowing locally created scripts to run while protecting against untrusted scripts. Apply the provided CLI command to adjust your PowerShell execution policy.</p>"
+            "target": "<p>Setting PowerShell's execution policy to Default helps prevent the execution of malicious scripts by requiring that all scripts and configuration files downloaded from the Internet are signed by a trusted publisher. This setting is a balance between security and functionality, allowing locally created scripts to run while protecting against untrusted scripts. Apply the provided CLI command to adjust your PowerShell execution policy.</p>"
           },
           {
             "locale": "FR",
             "class": "html",
-            "target": "<p>Définir la politique d'exécution de PowerShell sur RemoteSigned aide à prévenir l'exécution de scripts malveillants en exigeant que tous les scripts et fichiers de configuration téléchargés depuis Internet soient signés par un éditeur de confiance. Ce paramètre est un équilibre entre sécurité et fonctionnalité, permettant l'exécution de scripts créés localement tout en protégeant contre les scripts non fiables. Appliquez la commande CLI fournie pour ajuster votre politique d'exécution PowerShell.</p>"
+            "target": "<p>Définir la politique d'exécution de PowerShell sur Default aide à prévenir l'exécution de scripts malveillants en exigeant que tous les scripts et fichiers de configuration téléchargés depuis Internet soient signés par un éditeur de confiance. Ce paramètre est un équilibre entre sécurité et fonctionnalité, permettant l'exécution de scripts créés localement tout en protégeant contre les scripts non fiables. Appliquez la commande CLI fournie pour ajuster votre politique d'exécution PowerShell.</p>"
           }
         ]
       },
@@ -1304,7 +1304,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "system",
-        "target": "Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force",
+        "target": "Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser",
         "education": [
           {
             "locale": "EN",


### PR DESCRIPTION
# Pull request

## Describe your changes
- Set ExecutionPolicy to Default instead of RemoteSigned =>https://learn.microsoft.com/fr-fr/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.4#powershell-execution-policies
- CurrentUser scope policies are set since it has precedence on default scope (LocalMachine) => https://learn.microsoft.com/fr-fr/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.4#execution-policy-precedence
- Change threat data (title, descr., etc)

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have added tests to prove that my code is effective
- [ ] I have made the corresponding changes to the documentation

## Additional notes

