### PR TITLE
fix - stealthmode is not recognised as disabled until firewall restarts

### DIFF
--- a/threatmodel-macOS.json
+++ b/threatmodel-macOS.json
@@ -121,7 +121,7 @@
         "maxversion": 0,
         "class": "cli",
         "elevation": "system",
-        "target": "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode off",
+        "target": "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode off && defaults write /Library/Preferences/com.apple.alf globalstate -int 0; sleep 1; defaults write /Library/Preferences/com.apple.alf globalstate -int 1",
         "education": [
           {
             "locale": "EN",
@@ -142,9 +142,7 @@
       "dimension": "system integrity",
       "severity": 5,
       "scope": "generic",
-      "tags": [
-        "Personal Posture"
-      ],
+      "tags": ["Personal Posture"],
       "description": [
         {
           "locale": "EN",
@@ -213,9 +211,7 @@
       "dimension": "system integrity",
       "severity": 5,
       "scope": "macOS",
-      "tags": [
-        "Personal Posture"
-      ],
+      "tags": ["Personal Posture"],
       "description": [
         {
           "locale": "EN",
@@ -838,9 +834,7 @@
       "dimension": "system integrity",
       "severity": 4,
       "scope": "generic",
-      "tags": [
-        "Personal Posture"
-      ],
+      "tags": ["Personal Posture"],
       "description": [
         {
           "locale": "EN",


### PR DESCRIPTION
# Pull request

## Issue referencing
closes #4 

## Describe your changes
Reset firewall after disabling the stealthmode.

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have added tests to prove that my code is effective
- [ ] I have made the corresponding changes to the documentation

## Additional notes
Closes the issue in the edamame repository.

