### PR TITLE
ci: add regen_sigs workflow

### DIFF
--- a/.github/workflows/regen_sigs.yml
+++ b/.github/workflows/regen_sigs.yml
@@ -1,0 +1,68 @@
+name: Regenerate signatures
+on:
+  pull_request:
+    branches: ["main", "dev"]
+    paths:
+      - 'threatmodel-*.json'
+      - 'whitelists-db.json'
+      - 'blacklists-db.json'
+      - 'lanscan-profiles-db.json'
+      - 'sensitive-paths-db.json'
+      - 'cve-detection-params-db.json'
+      - 'lanscan-port-vulns-db.json'
+      - 'lanscan-vendor-vulns-db.json'
+
+# Auto cancel previous runs if they were not completed.
+concurrency:
+  group: regen-sigs-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  regen:
+    # Skip on PRs from forks (they cannot access DEV_GITHUB_TOKEN) and on
+    # commits authored by edamamedev itself (to avoid an infinite loop if a
+    # previous run already regenerated the .sig files).
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'edamamedev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.DEV_GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v3.1.4
+        with:
+          python-version: 3.11.3
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Regenerate signatures
+        run: make update
+
+      - name: Configure git
+        run: |
+          git config user.email "dev@edamame.tech"
+          git config user.name "EDAMAME Dev"
+
+      - name: Commit + push if changed
+        run: |
+          if git diff --quiet; then
+            echo "No signature regeneration needed."
+            exit 0
+          fi
+          git add .
+          git commit -m "Regenerate signatures"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Summary

Auto-regenerates signature files on every PR that touches one of the
tracked data sources, and pushes the regenerated `.sig` (and in-JSON
`signature` field) back to the PR branch so the `validate` gate sees a
matching hash.

## Why

The `Validation` ruleset on `main` (id `5800027`, just updated) now
requires 9 status checks for every PR:

- `validate` (test_validate.yml)
- `tests-native (ubuntu-x86_64 | ubuntu-aarch64 | macos-14 | macos-15 | macos-26 | windows)`
- `tests-alpine (alpine-x86_64 | alpine-aarch64)`

`validate-models.py` hard-fails on signature mismatch, which makes the
sig file the most common reason for a PR to get stuck at the gate. The
existing scheduled workflows (`update_blacklists_db.yml`,
`update_vulns_db.yml`) already write matching sigs because their build
scripts call the signing helper directly. Human-authored and code-update
skill PRs rely on `make update` -- and a missing `make update` would
otherwise block the PR until the contributor pushes the corrected sig
themselves.

With this workflow, the sig drift heals itself on push.

## Test plan

This PR itself is the test:

- [ ] All 9 required checks (`validate` + 6 native + 2 alpine) report green.
- [ ] `regen_sigs` is a no-op here (no data file touched in this PR).
- [ ] After this lands, the next data-touching PR (or scheduled
  blacklist/vulns PR) successfully heals sig drift if any is introduced.