### PR TITLE
ci: lift org IP allow list in regen_sigs.yml before push-back

### DIFF
--- a/.github/workflows/regen_sigs.yml
+++ b/.github/workflows/regen_sigs.yml
@@ -32,6 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Setup EDAMAME Posture
+        uses: edamametechnologies/edamame_posture_action@v1
+        with:
+          edamame_user: ${{ vars.EDAMAME_POSTURE_USER }}
+          edamame_domain: ${{ vars.EDAMAME_POSTURE_DOMAIN }}
+          edamame_pin: ${{ secrets.EDAMAME_POSTURE_PIN }}
+          edamame_id: ${{ github.run_id }}
+          # Lift the org IP allow list so the later git push back to the PR
+          # head ref is permitted from this github-hosted runner.
+          wait_for_api: true
+
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Add a `Setup EDAMAME Posture` step at the top of the `regen_sigs` job so the github-hosted runner's egress IP is whitelisted by the org IP allow list before the workflow pushes regenerated signatures back to the PR head ref.

## Why
The signature-regen workflow does a `git push` back to the PR head from a github-hosted runner. The `edamametechnologies` org enforces an IP allow list, and github-hosted runner pools are not in it, so the push-back returns HTTP 403. Running the posture action in connected mode lifts the allow list for the duration of the job.