### PR TITLE
gitignore: keep compiled CLAUDE.md and AGENTS.md as local setup.sh links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ __pycache__/
 report-results.txt
 /src/test/target/
 /src/test/Cargo.lock
+
+# AI rules: dev-only symlinks into ../edamame_rules, recreated by edamame_rules/setup.sh
+.claude/
+CLAUDE.md
+AGENTS.md


### PR DESCRIPTION
## Summary
- Ignore locally generated `CLAUDE.md` and `AGENTS.md` so `edamame_rules/setup.sh` can recreate them as symlinks without dirtying the working tree.

This is gitignore-only; no threatmodel JSON or signatures change.

## Test plan
- [x] Diff is `.gitignore` only (+5 lines)
- [ ] Validation / native / alpine status checks on this branch